### PR TITLE
Ignore node_modules

### DIFF
--- a/src/bin.js
+++ b/src/bin.js
@@ -13,7 +13,7 @@ import { saveResult, loadResult } from './file-report';
 import packageJSON from '../package.json';
 
 const DEFAULT_FILES = ['**/__benchmarks__/*.js'];
-const IGNORED_FILES = ['!node_modules'];
+const IGNORED_FILES = ['**/node_modules'];
 
 if (cluster.isMaster) {
     // Define global variables used by scenarios
@@ -80,8 +80,8 @@ if (cluster.isMaster) {
  */
 async function main() {
     const inputFiles = program.args.length == 0 ? DEFAULT_FILES : program.args;
-    const paths = await globby([...inputFiles, ...IGNORED_FILES], {
-        ignore: ['**/node_modules']
+    const paths = await globby(inputFiles, {
+        ignore: IGNORED_FILES
     });
 
     paths.forEach(filePath => {

--- a/src/bin.js
+++ b/src/bin.js
@@ -80,7 +80,9 @@ if (cluster.isMaster) {
  */
 async function main() {
     const inputFiles = program.args.length == 0 ? DEFAULT_FILES : program.args;
-    const paths = await globby([...inputFiles, ...IGNORED_FILES]);
+    const paths = await globby([...inputFiles, ...IGNORED_FILES], {
+        ignore: ['**/node_modules']
+    });
 
     paths.forEach(filePath => {
         // $FlowFixMe: flow doesn't accept dynamic require


### PR DESCRIPTION
node_modules were being ignores with an additional glob, but there's a low-level ignore option that can be passed to fast-glob. Do that.